### PR TITLE
feat(store): add fee multiplier param to sign and signCW

### DIFF
--- a/packages/store/src/cosmjs/sign.ts
+++ b/packages/store/src/cosmjs/sign.ts
@@ -180,6 +180,7 @@ export const sign = async (
   memo?: string,
   explicitSignerData?: SignerData,
   timeoutHeight?: bigint,
+  feeMultiplier: number = 1.4,
 ): Promise<TxRaw> => {
   const state = store.getState();
   assertIsDefined(state.wallet, 'wallet is undefined');
@@ -218,7 +219,14 @@ export const sign = async (
       gasPrice = await getGasPrice(chain);
     }
 
-    fee = await estimateFee(client, sender, messages, gasPrice, memo);
+    fee = await estimateFee(
+      client,
+      sender,
+      messages,
+      gasPrice,
+      memo,
+      feeMultiplier,
+    );
   }
 
   openWCDeeplink(state.wallet, state.openDeeplink);
@@ -250,6 +258,7 @@ export const signCW = async (
   memo?: string,
   explicitSignerData?: SignerData,
   timeoutHeight?: bigint,
+  feeMultiplier: number = 1.4,
 ): Promise<TxRaw> => {
   const state = store.getState();
   assertIsDefined(state.wallet);
@@ -290,7 +299,14 @@ export const signCW = async (
       gasPrice = await getGasPrice(chain);
     }
 
-    fee = await estimateFee(client, sender, messages, gasPrice, memo);
+    fee = await estimateFee(
+      client,
+      sender,
+      messages,
+      gasPrice,
+      memo,
+      feeMultiplier,
+    );
   }
 
   openWCDeeplink(state.wallet, state.openDeeplink);


### PR DESCRIPTION
### :nerd_face: Describe the purpose of the Pull Request

This PR is to allow specifying the fee multiplier when calling `sign()` and `signCW()` functions with fee is set to `auto`, and the default multiplier value of `1.4` is not enough for transactions to succeed.

### :rotating_light: Ensure to have answered all the submission questions

- [X] You read the guidelines for contributing.
- [X] You correctly created an issue about the things you want to solve with this PR.
- [X] You are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your main!
- [X] You checked the commits' message styles matches our requested structure.
- [X] You added necessary documentation (where needed).
- [X] You performed fully tests on your code.
- [ ] You are introducing breaking changes.

### :link: Issue linking

This is a very simple PR to resolve #93

### :heart: Thanks!

Thanks for taking the time in contributing to Quirks!