### PR TITLE
feat: cosmos registry

### DIFF
--- a/examples/nextjs/config.ts
+++ b/examples/nextjs/config.ts
@@ -1,11 +1,13 @@
 'use client';
 
 import {
-  cosmoshub,
-  cosmoshubAssetList,
-  osmosis,
-  osmosisAssetList,
-} from '@nabla-studio/chain-registry';
+  chain as osmosis,
+  assets as osmosisAssetList,
+} from 'chain-registry/mainnet/osmosis';
+import {
+  chain as cosmoshub,
+  assets as cosmoshubAssetList,
+} from 'chain-registry/mainnet/cosmoshub';
 import { generateConfig } from '@quirks/next';
 import {
   xdefiExtension,

--- a/examples/vue3/src/main.ts
+++ b/examples/vue3/src/main.ts
@@ -7,11 +7,13 @@ import { quirksPlugin } from '@quirks/vue';
 const app = createApp(App);
 
 import {
-  cosmoshub,
-  cosmoshubAssetList,
-  osmosis,
-  osmosisAssetList,
-} from '@nabla-studio/chain-registry';
+  chain as osmosis,
+  assets as osmosisAssetList,
+} from 'chain-registry/mainnet/osmosis';
+import {
+  chain as cosmoshub,
+  assets as cosmoshubAssetList,
+} from 'chain-registry/mainnet/cosmoshub';
 import type { Config } from '@quirks/store';
 import {
   cosmostationMobile,

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     }
   },
   "dependencies": {
+    "@chain-registry/types": "^0.45.46",
     "@cosmjs/amino": "^0.32.2",
     "@cosmjs/cosmwasm-stargate": "^0.32.2",
     "@cosmjs/proto-signing": "^0.32.2",
@@ -101,6 +102,7 @@
     "babel-plugin-module-resolver": "^5.0.0",
     "base64-js": "^1.5.1",
     "bufferutil": "^4.0.8",
+    "chain-registry": "^1.63.56",
     "cookies-next": "^4.2.1",
     "cosmjs-types": "^0.9.0",
     "eventemitter3": "^5.0.1",

--- a/packages/chain-registry/README.md
+++ b/packages/chain-registry/README.md
@@ -1,6 +1,8 @@
-# chain-registry
+# [DEPRECATED] chain-registry
 
 This library exports all cosmos chain configuration, both testnet and mainnet
+
+NOTE: **This library is deprecated, we only mantain it for older version of quirks.**
 
 ## Building
 

--- a/packages/core/.eslintrc.json
+++ b/packages/core/.eslintrc.json
@@ -30,7 +30,8 @@
               "eventemitter3",
               "@walletconnect/universal-provider",
               "@walletconnect/types",
-              "base64-js"
+              "base64-js",
+              "@chain-registry/types"
             ],
             "ignoredFiles": ["{projectRoot}/vite.config.{js,ts,mjs,mts}"]
           }

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,6 +15,7 @@
   "sideEffects": false,
   "type": "module",
   "dependencies": {
+    "@chain-registry/types": "^0.45.46",
     "@cosmjs/stargate": "^0.32.2",
     "@cosmjs/proto-signing": "^0.32.2",
     "cosmjs-types": "^0.9.0",
@@ -24,7 +25,6 @@
     "@walletconnect/types": "^2.11.2",
     "base64-js": "^1.5.1",
     "pino-pretty": "^10.2.3",
-    "@nabla-studio/chain-registry": "*",
     "@nabla-studio/wallet-registry": "*"
   },
   "main": "./index.js",

--- a/packages/core/src/types/suggest-chains.ts
+++ b/packages/core/src/types/suggest-chains.ts
@@ -1,4 +1,4 @@
-import type { AssetList, Chain } from '@nabla-studio/chain-registry';
+import type { AssetList, Chain } from '@chain-registry/types';
 
 export interface SuggestChain {
   name: string;

--- a/packages/core/src/utils/endpoints.ts
+++ b/packages/core/src/utils/endpoints.ts
@@ -1,17 +1,33 @@
-import type { Chain, Endpoint } from '@nabla-studio/chain-registry';
+import type { Chain } from '@chain-registry/types';
 import { assertIsDefined } from './asserts';
 
 export function getEndpoint(
   chainName: string,
   chains: Chain[],
 ): {
-  rpc: Endpoint;
-  rest: Endpoint;
+  rpc: {
+    address: string;
+    provider?: string;
+    archive?: boolean;
+  };
+  rest: {
+    address: string;
+    provider?: string;
+    archive?: boolean;
+  };
 };
 
 export function getEndpoint(chain: Chain): {
-  rpc: Endpoint;
-  rest: Endpoint;
+  rpc: {
+    address: string;
+    provider?: string;
+    archive?: boolean;
+  };
+  rest: {
+    address: string;
+    provider?: string;
+    archive?: boolean;
+  };
 };
 
 export function getEndpoint(chainOrName: string | Chain, chains: Chain[] = []) {

--- a/packages/core/src/utils/fees.ts
+++ b/packages/core/src/utils/fees.ts
@@ -2,7 +2,7 @@ import type { EncodeObject } from '@cosmjs/proto-signing';
 import { assertIsDefined } from './asserts';
 import type { GasPrice } from '@cosmjs/stargate';
 import type { SigningSimulatorClient } from '../types';
-import type { Chain } from '@nabla-studio/chain-registry';
+import type { Chain } from '@chain-registry/types';
 
 /**
  * Retrieve chain gas price so we can use fee auto.

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -45,7 +45,7 @@ export default defineConfig({
         '@cosmjs/amino',
         '@cosmjs/stargate',
         'eventemitter3',
-        '@nabla-studio/chain-registry',
+        '@chain-registry/types',
         '@nabla-studio/wallet-registry',
         '@walletconnect/universal-provider',
         '@walletconnect/types',

--- a/packages/store/.eslintrc.json
+++ b/packages/store/.eslintrc.json
@@ -28,7 +28,8 @@
               "@cosmjs/proto-signing",
               "@cosmjs/stargate",
               "@cosmjs/cosmwasm-stargate",
-              "@walletconnect/universal-provider"
+              "@walletconnect/universal-provider",
+              "@chain-registry/types"
             ],
             "ignoredFiles": ["{projectRoot}/vite.config.{js,ts,mjs,mts}"]
           }

--- a/packages/store/package.json
+++ b/packages/store/package.json
@@ -16,13 +16,13 @@
   "type": "module",
   "dependencies": {
     "zustand": "^4.5.0",
+    "@chain-registry/types": "^0.45.46",
     "@cosmjs/amino": "^0.32.2",
     "@cosmjs/proto-signing": "^0.32.2",
     "@cosmjs/stargate": "^0.32.2",
     "@cosmjs/cosmwasm-stargate": "^0.32.2",
     "@walletconnect/universal-provider": "^2.11.2",
     "cosmjs-types": "^0.9.0",
-    "@nabla-studio/chain-registry": "*",
     "@quirks/core": "*"
   },
   "main": "./index.js",

--- a/packages/store/src/cosmjs/broadcast.ts
+++ b/packages/store/src/cosmjs/broadcast.ts
@@ -5,7 +5,7 @@ import type {
   SigningStargateClientOptions,
 } from '@cosmjs/stargate';
 import type { TxRaw } from 'cosmjs-types/cosmos/tx/v1beta1/tx';
-import type { Chain } from '@nabla-studio/chain-registry';
+import type { Chain } from '@chain-registry/types';
 import { getChain } from './utils';
 
 export async function broadcast(

--- a/packages/store/src/cosmjs/sign.ts
+++ b/packages/store/src/cosmjs/sign.ts
@@ -20,7 +20,7 @@ import type {
 import type { TxRaw } from 'cosmjs-types/cosmos/tx/v1beta1/tx';
 import type { SignerType } from '../types';
 import { getAddress, getChain } from './utils';
-import { Chain } from '@nabla-studio/chain-registry';
+import type { Chain } from '@chain-registry/types';
 
 export function getOfflineSigner(
   chainId: string,

--- a/packages/store/src/types/config.ts
+++ b/packages/store/src/types/config.ts
@@ -1,4 +1,4 @@
-import type { AssetList, Chain } from '@nabla-studio/chain-registry';
+import type { AssetList, Chain } from '@chain-registry/types';
 import type { Wallet } from '@quirks/core';
 
 export interface ConfigState {

--- a/packages/store/src/types/options.ts
+++ b/packages/store/src/types/options.ts
@@ -1,5 +1,5 @@
 import type { OpenDeeplinkCallback, SignOptions, Wallet } from '@quirks/core';
-import type { AssetList, Chain } from '@nabla-studio/chain-registry';
+import type { AssetList, Chain } from '@chain-registry/types';
 import type {
   SigningStargateClientOptions,
   StargateClientOptions,

--- a/packages/store/vite.config.ts
+++ b/packages/store/vite.config.ts
@@ -49,7 +49,7 @@ export default defineConfig({
         'cosmjs-types',
         'cosmjs-types/cosmos/tx/v1beta1/tx',
         '@quirks/core',
-        '@nabla-studio/chain-registry',
+        '@chain-registry/types',
         '@walletconnect/universal-provider',
       ],
     },

--- a/packages/wallets/.eslintrc.json
+++ b/packages/wallets/.eslintrc.json
@@ -30,7 +30,8 @@
               "long",
               "cosmjs-types",
               "@leapwallet/cosmos-snap-provider",
-              "@dao-dao/cosmiframe"
+              "@dao-dao/cosmiframe",
+              "@chain-registry/types"
             ],
             "ignoredFiles": ["{projectRoot}/vite.config.{js,ts,mjs,mts}"]
           }

--- a/packages/wallets/package.json
+++ b/packages/wallets/package.json
@@ -15,8 +15,8 @@
   "sideEffects": false,
   "type": "module",
   "dependencies": {
+    "@chain-registry/types": "^0.45.46",
     "@quirks/core": "*",
-    "@nabla-studio/chain-registry": "*",
     "@nabla-studio/wallet-registry": "*",
     "@keplr-wallet/types": "^0.12.86",
     "@cosmostation/extension-client": "^0.1.15",

--- a/packages/wallets/src/cosmostation/utils.ts
+++ b/packages/wallets/src/cosmostation/utils.ts
@@ -1,5 +1,5 @@
 import type { AddChainParams } from '@cosmostation/extension-client/types/message';
-import type { AssetList, Chain } from '@nabla-studio/chain-registry';
+import type { AssetList, Chain } from '@chain-registry/types';
 import {
   defaultChainInfoOptions,
   getChainInfo,

--- a/packages/wallets/src/types/keplr.ts
+++ b/packages/wallets/src/types/keplr.ts
@@ -1,4 +1,4 @@
-import type { Chain } from '@nabla-studio/chain-registry';
+import type { Chain } from '@chain-registry/types';
 
 export interface ChainInfoOptions {
   getRpcEndpoint: (chain: Chain) => string;

--- a/packages/wallets/src/utils/chain.ts
+++ b/packages/wallets/src/utils/chain.ts
@@ -1,5 +1,5 @@
 import type { Bech32Config } from '@keplr-wallet/types';
-import type { Chain } from '@nabla-studio/chain-registry';
+import type { Chain } from '@chain-registry/types';
 
 export const getRpc = (chain: Chain): string =>
   chain.apis?.rpc?.[0]?.address ?? '';

--- a/packages/wallets/src/utils/wallet.test.ts
+++ b/packages/wallets/src/utils/wallet.test.ts
@@ -1,9 +1,11 @@
 import {
-  osmosis,
-  osmosisAssetList,
-  bitsong,
-  bitsongAssetList,
-} from '@nabla-studio/chain-registry';
+  chain as osmosis,
+  assets as osmosisAssetList,
+} from 'chain-registry/mainnet/osmosis';
+import {
+  chain as bitsong,
+  assets as bitsongAssetList,
+} from 'chain-registry/mainnet/bitsong';
 import { getChainInfo } from './wallet';
 import type { ChainInfo } from '@keplr-wallet/types';
 

--- a/packages/wallets/src/utils/wallet.ts
+++ b/packages/wallets/src/utils/wallet.ts
@@ -1,4 +1,4 @@
-import type { Asset, AssetList, Chain } from '@nabla-studio/chain-registry';
+import type { Asset, AssetList, Chain } from '@chain-registry/types';
 import type { ChainInfo, Currency, FeeCurrency } from '@keplr-wallet/types';
 import type { ChainInfoOptions } from '../types';
 import { getBech32Config, getExplr, getRest, getRpc } from './chain';
@@ -32,7 +32,7 @@ export const cosmwasmFeatures = {
 /**
  * The first version of the following utility is derived by a code which lays under an [MIT license](./Cosmology-LICENSE).
  *
- * @param chain An object that contains the chain configuration, can be retrieved from the chain-registry (@nabla-studio/chain-registry)
+ * @param chain An object that contains the chain configuration, can be retrieved from the chain-registry (chain-registry)
  * @param assets An array containing objects represented the token information of the chain passed before can be retrieved from the chain-registry
  * @param options An object to configure and customize some setup behaviors, particularly how endpoints are derived
  * @returns Returns a `ChainInfo` object compatible with the data types exposed by keplr and other wallets

--- a/packages/wallets/vite.config.ts
+++ b/packages/wallets/vite.config.ts
@@ -46,7 +46,7 @@ export default defineConfig({
         '@cosmjs/amino',
         'long',
         '@quirks/core',
-        '@nabla-studio/chain-registry',
+        '@chain-registry/types',
         '@nabla-studio/wallet-registry',
         '@cosmostation/extension-client',
         '@leapwallet/cosmos-snap-provider',

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
 
   .:
     dependencies:
+      '@chain-registry/types':
+        specifier: ^0.45.46
+        version: 0.45.46
       '@cosmjs/amino':
         specifier: ^0.32.2
         version: 0.32.3
@@ -65,6 +68,9 @@ importers:
       bufferutil:
         specifier: ^4.0.8
         version: 4.0.8
+      chain-registry:
+        specifier: ^1.63.56
+        version: 1.63.56
       cookies-next:
         specifier: ^4.2.1
         version: 4.2.1
@@ -1113,6 +1119,9 @@ packages:
 
   '@bcoe/v8-coverage@0.2.3':
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
+
+  '@chain-registry/types@0.45.46':
+    resolution: {integrity: sha512-IsajdG7UYxflCC4abwCw0G91nW/nnNJGgnfeScFhGyvXBlCHRqUd7LLDrlfgJ5ag0px1ONZ3lBPX2+LcR57bJQ==}
 
   '@cloudflare/kv-asset-handler@0.3.2':
     resolution: {integrity: sha512-EeEjMobfuJrwoctj7FA1y1KEbM0+Q1xSjobIEyie9k4haVEBB7vkDvsasw1pM3rO39mL2akxIAzLMUAtrMHZhA==}
@@ -4487,6 +4496,9 @@ packages:
   chai@4.4.1:
     resolution: {integrity: sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==}
     engines: {node: '>=4'}
+
+  chain-registry@1.63.56:
+    resolution: {integrity: sha512-dJXvcDeoya584+kHn6TdkmJq5Fsg/6gd3GIWNd+nOVEjYaj/BoF9n+J2HzM5kY63mRm5/LOsxT9EFM+yPXAIIw==}
 
   chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
@@ -11394,6 +11406,8 @@ snapshots:
 
   '@bcoe/v8-coverage@0.2.3': {}
 
+  '@chain-registry/types@0.45.46': {}
+
   '@cloudflare/kv-asset-handler@0.3.2':
     dependencies:
       mime: 3.0.0
@@ -16722,6 +16736,10 @@ snapshots:
       loupe: 2.3.7
       pathval: 1.1.1
       type-detect: 4.0.8
+
+  chain-registry@1.63.56:
+    dependencies:
+      '@chain-registry/types': 0.45.46
 
   chalk@2.4.2:
     dependencies:


### PR DESCRIPTION
The goal of this PR is to deprecate @nabla-studio/chain-registry and migrate to the cosmos registry that is currently used by the community, considering that tree shaking issues have now been fixed, the library is usable without impacting the bundlesize