### PR TITLE
fix(wallets): :bug: fix buffer undefined error

### DIFF
--- a/packages/wallets/src/index.ts
+++ b/packages/wallets/src/index.ts
@@ -14,3 +14,4 @@ export * from './leap-mobile';
 export * from './cosmostation-mobile';
 export * from './trust-mobile';
 export * from './types';
+export * from './utils';

--- a/packages/wallets/src/utils/index.ts
+++ b/packages/wallets/src/utils/index.ts
@@ -1,0 +1,28 @@
+import type { Bech32Config } from '@keplr-wallet/types';
+
+/**
+ * Replace for @keplr-wallet/cosmos, we use this class insie @chain-registry/keplr,
+ * but @keplr-wallet/cosmos depends on Buffer from node and this create problem on web enviroment
+ */
+export class Bech32Address {
+  /**
+   * Returns bech32 address format as required by Keplr and other wallets
+   *
+   * @param prefix Chain bech32 prefix
+   * @returns a valid `Bech32Config`
+   */
+  static defaultBech32Config = (
+    prefix: string,
+    validatorPrefix: string = 'val',
+    consensusPrefix: string = 'cons',
+    publicPrefix: string = 'pub',
+    operatorPrefix: string = 'oper',
+  ): Bech32Config => ({
+    bech32PrefixAccAddr: prefix,
+    bech32PrefixAccPub: `${prefix}${publicPrefix}`,
+    bech32PrefixValAddr: `${prefix}${validatorPrefix}${operatorPrefix}`,
+    bech32PrefixValPub: `${prefix}${validatorPrefix}${operatorPrefix}${publicPrefix}`,
+    bech32PrefixConsAddr: `${prefix}${validatorPrefix}${consensusPrefix}`,
+    bech32PrefixConsPub: `${prefix}${validatorPrefix}${consensusPrefix}${publicPrefix}`,
+  });
+}

--- a/packages/wallets/vite.config.ts
+++ b/packages/wallets/vite.config.ts
@@ -7,6 +7,12 @@ import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
 export default defineConfig({
   cacheDir: '../../node_modules/.vite/wallets',
 
+  resolve: {
+    alias: {
+      '@keplr-wallet/cosmos': '@quirks/wallets',
+    },
+  },
+
   plugins: [
     nxViteTsPaths(),
     dts({
@@ -46,7 +52,6 @@ export default defineConfig({
         '@cosmjs/amino',
         'long',
         '@quirks/core',
-        '@chain-registry/keplr',
         '@chain-registry/types',
         '@nabla-studio/wallet-registry',
         '@cosmostation/extension-client',


### PR DESCRIPTION
### :nerd_face: Describe the purpose of the Pull Request

This PR address the issue reported here: #105 

It's due to @keplr-wallet/cosmos, because it depends on Buffer lib, so instead of importing it we just replace it with a simpler implementation (because we just use a single function)